### PR TITLE
Fix metrics for resolved messages

### DIFF
--- a/ServiceControlExporter.sln
+++ b/ServiceControlExporter.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4AC4C2CC-05E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "service-control-exporter", "src\service-control-exporter\service-control-exporter.csproj", "{440B9615-F591-4907-9A00-F2299ED33E9D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D85AD24A-1574-4E5C-9C6B-4EE82273D0A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "service-control-exporter.Tests", "tests\service-control-exporter.Tests\service-control-exporter.Tests.csproj", "{CBD65D81-6184-493F-ABA2-97D407CBC0B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,8 +24,13 @@ Global
 		{440B9615-F591-4907-9A00-F2299ED33E9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{440B9615-F591-4907-9A00-F2299ED33E9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{440B9615-F591-4907-9A00-F2299ED33E9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBD65D81-6184-493F-ABA2-97D407CBC0B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBD65D81-6184-493F-ABA2-97D407CBC0B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBD65D81-6184-493F-ABA2-97D407CBC0B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBD65D81-6184-493F-ABA2-97D407CBC0B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{440B9615-F591-4907-9A00-F2299ED33E9D} = {4AC4C2CC-05E2-4CDC-BE45-6AD540E3CD7D}
+		{CBD65D81-6184-493F-ABA2-97D407CBC0B1} = {D85AD24A-1574-4E5C-9C6B-4EE82273D0A0}
 	EndGlobalSection
 EndGlobal

--- a/build.cake
+++ b/build.cake
@@ -31,9 +31,21 @@ Task("Clean")
         EnsureDirectoryDoesNotExist("./artifacts");
     });
 
-Task("Package")
-    .IsDependentOn("Version")
+Task("Test")
+    .Description("Executes tests")
     .IsDependentOn("Clean")
+    .IsDependentOn("Version")
+    .Does(() => {
+        var dotnetTestSettings = new DotNetTestSettings
+        {
+            Configuration = configuration,
+        };
+
+        DotNetTest(SOLUTION_FILE, dotnetTestSettings);
+    });
+
+Task("Package")
+    .IsDependentOn("Test")
     .Description("Creates packages for the exporter.")
     .Does(() => {
         var msBuildSettings = new DotNetMSBuildSettings()

--- a/src/service-control-exporter/Infrastructure/ServiceControlPollBackgroundService.cs
+++ b/src/service-control-exporter/Infrastructure/ServiceControlPollBackgroundService.cs
@@ -27,7 +27,7 @@ public class ServiceControlPollBackgroundService : BackgroundService
 
         var timer = new PeriodicTimer(Options.RequestInterval);
 
-        while (await timer.WaitForNextTickAsync(stoppingToken))
+        do
         {
             Logger.LogDebug("Attempting to update metrics from ServiceControl.");
             try
@@ -41,7 +41,7 @@ public class ServiceControlPollBackgroundService : BackgroundService
             {
                 Logger.LogError(ex, "Can't update metrics from ServiceControl.");
             }
-        }
+        } while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
     }
 }
 

--- a/src/service-control-exporter/InstallAsWindowsService.ps1
+++ b/src/service-control-exporter/InstallAsWindowsService.ps1
@@ -1,2 +1,2 @@
-sc.exe create "ServiceControlExporter" binpath="$(pwd)/service-control-exporter.exe"
+sc.exe create "ServiceControlExporter" startup= delayed-auto binpath="$(pwd)/service-control-exporter.exe"
 # sc.exe failure "ServiceControlExporter" reset=0 actions=restart/60000/restart/60000/run/1000

--- a/src/service-control-exporter/Metrics/ObservableMetrics.cs
+++ b/src/service-control-exporter/Metrics/ObservableMetrics.cs
@@ -4,7 +4,7 @@ using ServiceControlExporter.ServiceControl;
 
 namespace ServiceControlExporter.Metrics;
 
-internal sealed class ObservableMetrics
+public sealed class ObservableMetrics
 {
     public IReadOnlyList<EndpointGroup> MessagesPerEndpoint { get; private set; } = Array.Empty<EndpointGroup>();
     public IReadOnlyList<EndpointGroup> MessagesPerMessageType { get; private set; } = Array.Empty<EndpointGroup>();

--- a/src/service-control-exporter/Metrics/ServiceControlMeter.cs
+++ b/src/service-control-exporter/Metrics/ServiceControlMeter.cs
@@ -23,10 +23,9 @@ internal class ServiceControlMeter
         ErrorMessagesPerMessageType = Meter.CreateObservableGauge("ErrorMessagesPerType", () => ToMeasurements(ObservableMetrics.MessagesPerMessageType, "type"), unit: "Messages", description: "Shows the amount of error messages per message type that require manual review.");
     }
 
-    private static IEnumerable<Measurement<int>> ToMeasurements(IEnumerable<EndpointGroup> endpointGroups, string tagName)
+    private static IEnumerable<Measurement<int>> ToMeasurements(ConcurrentDictionary<string, int> endpointGroups, string tagName)
     {
         return endpointGroups
-            .Select(s => new Measurement<int>(s.Count, new KeyValuePair<string, object?>[] {new(tagName, s.Title)}))
-            .DefaultIfEmpty(new Measurement<int>(0));
+            .Select(s => new Measurement<int>(s.Value, new KeyValuePair<string, object?>[] {new(tagName, s.Key)}));
     }
 }

--- a/src/service-control-exporter/Program.cs
+++ b/src/service-control-exporter/Program.cs
@@ -32,7 +32,10 @@ builder.Services.AddHttpClient(ServiceControlApi.HTTP_CLIENT_NAME, c => {
 // Add services to the container.
 builder.Services.AddOpenTelemetry()
     .WithMetrics(builder => builder
-        .AddPrometheusExporter()
+        .AddPrometheusExporter(e => 
+        {
+            e.ScrapeResponseCacheDurationMilliseconds = 0;
+        })
         .AddMeter(ServiceControlMeter.NAME))
     .StartWithHost();
 

--- a/src/service-control-exporter/Program.cs
+++ b/src/service-control-exporter/Program.cs
@@ -8,8 +8,6 @@ using ServiceControlExporter.Infrastructure;
 using ServiceControlExporter.Metrics;
 using ServiceControlExporter.ServiceControl;
 
-using Microsoft.Extensions.Hosting;
-
 var builder = WebApplication.CreateBuilder(args);
 
 Log.Logger = new LoggerConfiguration()
@@ -45,3 +43,6 @@ var meter = app.Services.GetRequiredService<ServiceControlMeter>();
 
 app.UseOpenTelemetryPrometheusScrapingEndpoint();
 app.Run();
+
+
+public partial class Program {}

--- a/src/service-control-exporter/ServiceControl/IServiceControlApi.cs
+++ b/src/service-control-exporter/ServiceControl/IServiceControlApi.cs
@@ -1,6 +1,6 @@
 namespace ServiceControlExporter.ServiceControl;
 
-internal interface IServiceControlApi
+public interface IServiceControlApi
 {
     Task<IEnumerable<EndpointGroup>> GetErrorMessageSummaryPerEndpoint();
     Task<IEnumerable<EndpointGroup>> GetErrorMessageSummaryPerType();

--- a/tests/service-control-exporter.Tests/Integration/IntegrationTest.cs
+++ b/tests/service-control-exporter.Tests/Integration/IntegrationTest.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using NUnit.Framework;
+
+namespace ServiceControlExporter.Tests.Integration;
+
+public class IntegrationTest
+{
+    protected ServiceControlExporterWebApplicationFactory ServiceControlExporterWebApplicationFactory { get; private set; } = null;
+    protected HttpClient ServiceControlExporterClient { get; private set; } = null;
+
+    protected void SetupApplication()
+    {
+        ServiceControlExporterWebApplicationFactory = new ServiceControlExporterWebApplicationFactory();
+        ServiceControlExporterClient = ServiceControlExporterWebApplicationFactory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+    }
+}

--- a/tests/service-control-exporter.Tests/Integration/IntegrationTest.cs
+++ b/tests/service-control-exporter.Tests/Integration/IntegrationTest.cs
@@ -5,8 +5,8 @@ namespace ServiceControlExporter.Tests.Integration;
 
 public class IntegrationTest
 {
-    protected ServiceControlExporterWebApplicationFactory ServiceControlExporterWebApplicationFactory { get; private set; } = null;
-    protected HttpClient ServiceControlExporterClient { get; private set; } = null;
+    protected ServiceControlExporterWebApplicationFactory ServiceControlExporterWebApplicationFactory { get; private set; }
+    protected HttpClient ServiceControlExporterClient { get; private set; }
 
     protected void SetupApplication()
     {

--- a/tests/service-control-exporter.Tests/Integration/MetricsEndpointTests.cs
+++ b/tests/service-control-exporter.Tests/Integration/MetricsEndpointTests.cs
@@ -1,0 +1,75 @@
+using ServiceControlExporter.ServiceControl;
+using ServiceControlExporter.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
+
+namespace ServiceControlExporter.Tests.Integration;
+
+public class MetricsEndpointTest : IntegrationTest
+{
+    [SetUp]
+    public void Setup()
+    {
+        // Setup application per test to have a clear baseline
+        SetupApplication();
+    }
+
+    [Test]
+    public async Task Returns_Count_Of_Messages_Per_Endpoint()
+    {
+        var api = ServiceControlExporterWebApplicationFactory.MockServiceControlApi;
+        api.Setup(m => m.GetErrorMessageSummaryPerEndpoint()).ReturnsAsync(new [] {new EndpointGroup { Title = "EndpointName", Count = 1 }});
+
+        var metrics = ServiceControlExporterWebApplicationFactory.Server.Services.GetRequiredService<ObservableMetrics>();
+        await metrics.Update(CancellationToken.None).ConfigureAwait(false);
+
+        var response = await ServiceControlExporterClient.GetAsync("/metrics").ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        content.Should().Contain("ErrorMessagesPerEndpoint_Messages{endpoint=\"EndpointName\"} 1");
+    }
+
+    [Test]
+    public async Task Returns_Count_Of_Messages_Per_MessageType()
+    {
+        var api = ServiceControlExporterWebApplicationFactory.MockServiceControlApi;
+        api.Setup(m => m.GetErrorMessageSummaryPerType()).ReturnsAsync(new [] { new EndpointGroup { Title = "MessageType", Count = 1 }});
+
+        var metrics = ServiceControlExporterWebApplicationFactory.Server.Services.GetRequiredService<ObservableMetrics>();
+        await metrics.Update(CancellationToken.None).ConfigureAwait(false);
+
+        var response = await ServiceControlExporterClient.GetAsync("/metrics").ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        content.Should().Contain("ErrorMessagesPerType_Messages{type=\"MessageType\"} 1");
+    }
+
+    [Test]
+    public async Task Returns_0_As_Count_For_Endpoint_That_Previously_Had_Messages_And_Is_No_Longer_Reported_By_The_Api()
+    {
+        var api = ServiceControlExporterWebApplicationFactory.MockServiceControlApi;
+        api.Setup(m => m.GetErrorMessageSummaryPerEndpoint()).ReturnsAsync(new [] {new EndpointGroup { Title = "EndpointName", Count = 1 }});
+        api.Setup(m => m.GetErrorMessageSummaryPerType()).ReturnsAsync(new [] { new EndpointGroup { Title = "MessageType", Count = 1 }});
+
+        var metrics = ServiceControlExporterWebApplicationFactory.Server.Services.GetRequiredService<ObservableMetrics>();
+        await metrics.Update(CancellationToken.None).ConfigureAwait(false);
+
+        var response = await ServiceControlExporterClient.GetAsync("/metrics").ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        // Simulate retried or deleted messages
+        api.Setup(m => m.GetErrorMessageSummaryPerEndpoint()).ReturnsAsync(Array.Empty<EndpointGroup>());
+        api.Setup(m => m.GetErrorMessageSummaryPerType()).ReturnsAsync(Array.Empty<EndpointGroup>());
+        await metrics.Update(CancellationToken.None).ConfigureAwait(false);
+
+        // get the new metrics
+        response = await ServiceControlExporterClient.GetAsync("/metrics").ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        content.Should().Contain("ErrorMessagesPerType_Messages{type=\"MessageType\"} 0");
+        content.Should().Contain("ErrorMessagesPerEndpoint_Messages{endpoint=\"EndpointName\"} 0");
+    }
+}

--- a/tests/service-control-exporter.Tests/Integration/ServiceControlWebApplicationFactory.cs
+++ b/tests/service-control-exporter.Tests/Integration/ServiceControlWebApplicationFactory.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Mvc.Testing;
+using ServiceControlExporter.ServiceControl;
+using ServiceControlExporter.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+
+namespace ServiceControlExporter.Tests.Integration;
+
+public class ServiceControlExporterWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public Mock<IServiceControlApi> MockServiceControlApi { get; set; } = new Mock<IServiceControlApi>();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // replace ServiceControl api with a mock
+            var serviceControlApi = services.Single(
+                d => d.ServiceType == typeof(IServiceControlApi));
+            services.Remove(serviceControlApi!);
+            services.AddSingleton<IServiceControlApi>(MockServiceControlApi.Object);
+
+            // remove hosted service to avoid timer interfering with tests
+            var hostedService = services.Single(d => d.ImplementationType == typeof(ServiceControlPollBackgroundService));
+        });
+
+        builder.UseEnvironment("Testing");
+    }
+}

--- a/tests/service-control-exporter.Tests/Unit/Metrics/ObservableMetricsTests.cs
+++ b/tests/service-control-exporter.Tests/Unit/Metrics/ObservableMetricsTests.cs
@@ -1,0 +1,61 @@
+using ServiceControlExporter.Metrics;
+using ServiceControlExporter.ServiceControl;
+using Microsoft.Extensions.Logging;
+
+namespace ServiceControlExporter.Tests.Unit.Metrics;
+
+public class ObservableMetricsTests
+{
+    protected ObservableMetrics _metrics;
+    protected Mock<IServiceControlApi> _api;
+
+    [SetUp]
+    public void Setup()
+    {
+        _api = new Mock<IServiceControlApi>();
+        _metrics = new ObservableMetrics(_api.Object, Mock.Of<ILogger<ObservableMetrics>>());
+    }
+
+    public class UpdateMethod : ObservableMetricsTests
+    {
+        [Test]
+        public async Task Fills_The_Dictionaries_With_Current_Values_By_The_Api()
+        {
+            _api.Setup(m => m.GetErrorMessageSummaryPerEndpoint()).ReturnsAsync(new [] {new EndpointGroup { Title = "EndpointName", Count = 1 }});
+            _api.Setup(m => m.GetErrorMessageSummaryPerType()).ReturnsAsync(new [] { new EndpointGroup { Title = "MessageType", Count = 1 }});
+            
+            await _metrics.Update(CancellationToken.None).ConfigureAwait(false);
+
+            _metrics.MessagesPerEndpoint.Should().Contain("EndpointName", 1);
+            _metrics.MessagesPerMessageType.Should().Contain("MessageType", 1);
+        }
+
+        [Test]
+        public async Task Overwrites_Existing_Values()
+        {
+            _metrics.MessagesPerEndpoint["EndpointName"] = 5;
+            _metrics.MessagesPerMessageType["MessageType"] = 5;
+            _api.Setup(m => m.GetErrorMessageSummaryPerEndpoint()).ReturnsAsync(new [] {new EndpointGroup { Title = "EndpointName", Count = 1 }});
+            _api.Setup(m => m.GetErrorMessageSummaryPerType()).ReturnsAsync(new [] { new EndpointGroup { Title = "MessageType", Count = 1 }});
+
+            await _metrics.Update(CancellationToken.None).ConfigureAwait(false);
+
+            _metrics.MessagesPerEndpoint.Should().Contain("EndpointName", 1);
+            _metrics.MessagesPerMessageType.Should().Contain("MessageType", 1);
+        }
+
+        [Test]
+        public async Task Resets_Count_To_0_If_Values_Per_Endpoint_Or_Message_Are_No_Longer_Returned_By_The_Api()
+        {
+            _metrics.MessagesPerEndpoint["EndpointName"] = 5;
+            _metrics.MessagesPerMessageType["MessageType"] = 5;
+            _api.Setup(m => m.GetErrorMessageSummaryPerEndpoint()).ReturnsAsync(Array.Empty<EndpointGroup>());
+            _api.Setup(m => m.GetErrorMessageSummaryPerType()).ReturnsAsync(Array.Empty<EndpointGroup>());
+
+            await _metrics.Update(CancellationToken.None).ConfigureAwait(false);
+
+            _metrics.MessagesPerEndpoint.Should().Contain("EndpointName", 0);
+            _metrics.MessagesPerMessageType.Should().Contain("MessageType", 0);
+        }
+    }
+}

--- a/tests/service-control-exporter.Tests/Usings.cs
+++ b/tests/service-control-exporter.Tests/Usings.cs
@@ -1,0 +1,3 @@
+global using NUnit.Framework;
+global using Moq;
+global using FluentAssertions;

--- a/tests/service-control-exporter.Tests/service-control-exporter.Tests.csproj
+++ b/tests/service-control-exporter.Tests/service-control-exporter.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>ServiceControlExporter.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\service-control-exporter\service-control-exporter.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Add some tests for verifying behaviour + fix stale metrics in prometheus exporter if they are no longer returned via the api. For example when they were resolved or deleted.